### PR TITLE
Fix base class init

### DIFF
--- a/extensions/nautilus-git-gui.py
+++ b/extensions/nautilus-git-gui.py
@@ -9,9 +9,9 @@
 import os, subprocess
 from gi.repository import Nautilus, GObject
 
-class NautilusGitGUI(Nautilus.MenuProvider, GObject.GObject):
+class NautilusGitGUI(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
-        pass
+        super().__init__()
 
     def get_background_items(self, window, file):
         # Add the menu items


### PR DESCRIPTION
before this change nautilus 3.38 gave 
RuntimeError: object at 0x7f95d6c70cc0 of type NautilusGitGUI is not initialized